### PR TITLE
minor suggestions for frequency spectrum branch

### DIFF
--- a/inst/researchcode/frequency_domain_analyses.R
+++ b/inst/researchcode/frequency_domain_analyses.R
@@ -20,7 +20,7 @@ if (!file.exists(filename_flatHA)) {
 }
 load(filename_flatHA)
 
-deriveSpectrum <- function(x, sampling_frequency, plot = TRUE) {
+deriveSpectrum <- function(x, sampling_frequency) {
   specd.raw <- spectrum(x, log = "no", plot = FALSE) # the default for spectrum is to calculate the spectrum on a log-scale
   #or smooth the spectrum/data using a filter -> Butterworth band-pass filter?
   #spec.smooth <- spectrum(x, log = "no", span = 10) # use the argument span (specifies the parameter(s) for the what is known as the modified Daniell kernel) to smooth data
@@ -59,6 +59,6 @@ for(observation in 1:Nobs){
 names(freq_spec$periodigram_HA) <- ms_flat_HA$specifications$serial_number  
 names(freq_spec$periodigram_normHA) <- ms_flat_HA$specifications$serial_number  
 freq_spec$specifications <- ms_flat_HA$specifications
-print("Save data")
+cat("\nSaving data...")
 # setwd(datadir)
 save(freq_spec, file = paste0(datadir, "frequency_spectra.RData"))

--- a/inst/researchcode/frequency_domain_analyses.R
+++ b/inst/researchcode/frequency_domain_analyses.R
@@ -3,19 +3,24 @@ graphics.off()
 
 # Update to be your local directory, if all goes well this is the only line you will have to update
 shaker_experiments_folder = "/Users/annelindelettink/Documents/Work MacBook Pro Annelinde/Mechanical Shaker Machine"
-#shaker_experiments_folder = "~/data/VUMC/shaker_experiments"
+# shaker_experiments_folder = "~/data/VUMC/shaker_experiments"
 
 # TO DO: Check which GENEActiv was removed towards end of one of the experiments, and make sure data is not included
 
 #====================================================================================
 # Specify file paths
 datadir = paste0(shaker_experiments_folder, "/analyses/")
-
+if (!dir.exists(datadir)) {
+  stop(paste0("Directory does not exist: ", datadir))
+}
 # Load mechanical shaker data for horizontal axis 
-setwd(datadir)
-load(paste0(datadir, "ms_flat_HA.RData"))
+filename_flatHA = paste0(datadir, "ms_flat_HA.RData") 
+if (!file.exists(filename_flatHA)) {
+  stop(paste0("File does not exist: ", filename_flatHA))
+}
+load(filename_flatHA)
 
-deriveSpectrum <- function(x, sampling_frequency) {
+deriveSpectrum <- function(x, sampling_frequency, plot = TRUE) {
   specd.raw <- spectrum(x, log = "no", plot = FALSE) # the default for spectrum is to calculate the spectrum on a log-scale
   #or smooth the spectrum/data using a filter -> Butterworth band-pass filter?
   #spec.smooth <- spectrum(x, log = "no", span = 10) # use the argument span (specifies the parameter(s) for the what is known as the modified Daniell kernel) to smooth data
@@ -23,24 +28,37 @@ deriveSpectrum <- function(x, sampling_frequency) {
   specd.raw$specx <- specd.raw$freq/delta # spectrum calculates the frequency axis in terms of cycles per sampling interval -> convert to cycles per unit time (so divide by the sampling interval)
   specd.raw$specy <- 2*specd.raw$spec # spectrum needs to be multiplied by 2 to make it actually equal to variance
   #dom.freq.raw <- specx.raw[which.max(specy.raw)] # extract the dominant frequency
-  plot(specd.raw$specx, specd.raw$specy, xlab="Frequency (Hz)", ylab="Spectral Density (g2/Hz)", type="l", xlim = c(0,5)) # zoom in on low-frequencies, as at most 5 is expected based on max rpm)
   return(specd.raw)
 }
 
 freq_spec <- list()
-
-for(observation in 1:length(ms_flat_HA$data)){ 
+Nobs = length(ms_flat_HA$data)
+# plot parameters
+plot = TRUE
+xlabel = "Frequency (Hz)"
+ylabel = "Spectral Density (g2/Hz)"
+XLIM = c(0, 5)
+for(observation in 1:Nobs){ 
+  cat(paste0(observation, "/",  Nobs, " "))
   HA <- ms_flat_HA$data[[observation]]$x
   normHA <- ms_flat_HA$data[[observation]]$normHA
   sampling_frequency <- as.numeric(ms_flat_HA$specifications$sampling_frequency[observation])
-  spec.raw.HA <- deriveSpectrum(HA, sampling_frequency)
-  spec.raw.normHA <- deriveSpectrum(normHA, sampling_frequency)
+  # spec.raw.HA <- deriveSpectrum(HA, sampling_frequency)
+  # spec.raw.normHA <- deriveSpectrum(normHA, sampling_frequency)
   freq_spec$periodigram_HA[[observation]] <- deriveSpectrum(HA, sampling_frequency)
-  freq_spec$periodigram_normHA[[observation]] <- deriveSpectrum(normHA, sampling_frequency)   
+  freq_spec$periodigram_normHA[[observation]] <- deriveSpectrum(normHA, sampling_frequency)  
+  if (plot == TRUE) {
+    par(mfrow = c(1,2))
+    plot(freq_spec$periodigram_HA[[observation]]$specx, freq_spec$periodigram_HA[[observation]]$specy,
+         main = "HA", xlab = xlabel, ylab = ylabel, type = "l", xlim = XLIM, bty= "l") # zoom in on low-frequencies, as at most 5 is expected based on max rpm)
+    plot(freq_spec$periodigram_normHA[[observation]]$specx, freq_spec$periodigram_normHA[[observation]]$specy,
+         main = "normHA", xlab = xlabel, ylab =  ylabel, type = "l", xlim = XLIM, bty= "l") # zoom in on low-frequencies, as at most 5 is expected based on max rpm)
+  }
+
 }
 names(freq_spec$periodigram_HA) <- ms_flat_HA$specifications$serial_number  
 names(freq_spec$periodigram_normHA) <- ms_flat_HA$specifications$serial_number  
 freq_spec$specifications <- ms_flat_HA$specifications
-
-setwd(datadir)
-save(freq_spec, file = "frequency_spectra.RData")
+print("Save data")
+# setwd(datadir)
+save(freq_spec, file = paste0(datadir, "frequency_spectra.RData"))

--- a/inst/researchcode/subset_data_HA.R
+++ b/inst/researchcode/subset_data_HA.R
@@ -13,6 +13,7 @@ shaker_experiments_folder = "/Users/annelindelettink/Documents/Work MacBook Pro 
 # Specify file paths
 structured_data_dir = paste0(shaker_experiments_folder, "/structured_raw_data")
 outputdir = paste0(shaker_experiments_folder, "/analyses")
+if (!dir.exists(outputdir)) dir.create(outputdir)
 
 ## Subset data for the analyses into one data.frame for shaker experiment - flat
 # Required data: HA (horizontal axis; x-axis), and normalised HA = (HA - M) / SD
@@ -31,9 +32,9 @@ for (brand in 1:length(brands_to_load)) {
       cat(paste0("\nThis device was not included in experiment:"), experiments_to_load[experiment])
       next
     } else{
-      load(paste0(structured_data_dir, "/", brands_to_load[brand], "_", experiments_to_load[experiment]))
-      for (file in 1:length(extractedata$data)) {
-        tmp <- extractedata$data[[file]] #tmp is the structured data now
+      load(paste0(structured_data_dir, "/", brands_to_load[brand], "_", experiments_to_load[experiment], ".RData"))
+      for (file in 1:length(extracteddata$data)) {
+        tmp <- extracteddata$data[[file]] #tmp is the structured data now
         if(length(tmp > 0)) {
           if(brands_to_load[brand] %in% c("Actigraph", "Activpal")) {
             names(tmp) <- tolower(names(tmp))
@@ -43,8 +44,8 @@ for (brand in 1:length(brands_to_load)) {
           tmp$normHA <- (tmp$x - mean(tmp$x)) / sd(tmp$x) # normalize HA
           ms_flat_HA$data[[counter]] <- tmp
           counter = counter + 1
-          specs <- c(extractedata$specifications[file,"serial_number"], brands_to_load[brand], experiments_to_load[experiment], 
-                     extractedata$specifications[file,"sampling_frequency"], extractedata$specifications[file,"dynamic_range"])
+          specs <- c(extracteddata$specifications[file,"serial_number"], brands_to_load[brand], experiments_to_load[experiment], 
+                     extracteddata$specifications[file,"sampling_frequency"], extracteddata$specifications[file,"dynamic_range"])
           specifications <- rbind(specifications, unname(specs))
         }
       }
@@ -57,5 +58,4 @@ ms_flat_HA$specifications <- specifications
 as.factor(ms_flat_HA$specifications$brand)
 as.factor(ms_flat_HA$specifications$experiment)
 
-setwd(outputdir)
-save(ms_flat_HA, file = "ms_flat_HA.RData")
+save(ms_flat_HA, file = paste0(outputdir, "/ms_flat_HA.RData"))


### PR DESCRIPTION
Nice work. This PR are a few minor suggestions:

- Removed `setwd()` because usually people do not like it when their working directory is changed by a software. 
- Add a few checks that input folder and file exists.
- Added some `cat()` calls to print progress to console.
- Moved plotting outside `deriveSpectrum` to make it easier to plot both HA and HAnorm in the same figure. This seems to substantially speed up the loop.
- Commented out redundant calls to `deriveSpectrum`
- Added option to turn off plotting to make script run even faster.
- Replaced `extractedata` by `extracteddata` to be more grammatically correct and therefore less likely to cause bugs, because that is how I renamed it in the master branch and this is how I have the processed data locally.